### PR TITLE
Support a package.json esbuild field

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ The esbuild-config command outputs a list of parameters based on a `esbuild.conf
 esbuild $(esbuild-config)
 ```
 
-It detects the presence of `esbuild.config.json` in the current directory, or the project root (using the presence of a `package.json` file). Any file can also get provided as a parameter:
+It detects the presence of `esbuild.config.json` in the current directory or the project root (using the presence of a `package.json` file). The same configuration format can also get defined in the `package.json` file, using the `esbuild` field.json` file.
+
+A specific file path can also get passed as a parameter:
 
 ```console
 esbuild $(esbuild-config ./my-conf.json)
@@ -120,7 +122,7 @@ cargo run
 # Run the tests
 cargo test
 
-# Generate the code coverage report
+# Generate the code coverage report (install cargo-tarpaulin first)
 cargo tarpaulin -o Html
 ```
 

--- a/src/lib/args.rs
+++ b/src/lib/args.rs
@@ -2,8 +2,10 @@ use super::errors;
 use json;
 use snailquote;
 
-// Get the esbuild arguments from the data structure
-pub fn args_from_json_value(json: json::JsonValue) -> Result<String, errors::ConfigParseError> {
+// Get the esbuild arguments from the esbuild.config.json data structure
+pub fn args_from_config_json_value(
+    json: json::JsonValue,
+) -> Result<String, errors::ConfigParseError> {
     let mut args: Vec<String> = vec![];
     let mut entries: Vec<String> = vec![];
     let mut options: Vec<String> = vec![];
@@ -31,6 +33,18 @@ pub fn args_from_json_value(json: json::JsonValue) -> Result<String, errors::Con
     args.append(&mut options);
     args.append(&mut entries);
     Ok(args.join(" "))
+}
+
+// Get the esbuild arguments from the data structure of the package.json esbuild field
+pub fn args_from_package_json_value(
+    json: json::JsonValue,
+) -> Result<String, errors::ConfigParseError> {
+    if !json.is_object() {
+        return Err(errors::ConfigParseError::JsonError(json::Error::WrongType(
+            String::from("The package.json seems malformed."),
+        )));
+    }
+    args_from_config_json_value(json["esbuild"].clone())
 }
 
 // Get the entries in the config file
@@ -156,7 +170,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            args_from_json_value(value).unwrap(),
+            args_from_config_json_value(value).unwrap(),
             "--a --b=abc --c:def --c:ghi --d:e=jkl --d:f=mno index.js"
         );
     }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -5,15 +5,23 @@ mod paths;
 use json;
 use std::{fs, io, path};
 
-pub fn esbuild_conf(args: Vec<String>) -> Result<String, errors::EsbuildConfigError> {
-    let config_path =
-        paths::config_path(args.get(1)).map_err(|_| errors::EsbuildConfigError::ConfigPathError)?;
-    let config_content = esbuild_config_content(config_path)
-        .map_err(|_| errors::EsbuildConfigError::ConfigParseError)?;
-    parse_esbuild_config(config_content).map_err(|_| errors::EsbuildConfigError::ConfigParseError)
+pub enum ConfigFileType {
+    ConfigJson,
+    PackageJson,
 }
 
-pub fn esbuild_config_content(path: path::PathBuf) -> Result<String, errors::EsbuildConfigError> {
+pub fn esbuild_conf(args: Vec<String>) -> Result<String, errors::EsbuildConfigError> {
+    let (config_path, config_file_type) =
+        paths::config_path(args.get(1)).map_err(|_| errors::EsbuildConfigError::ConfigPathError)?;
+
+    let config_content =
+        read_json_content(config_path).map_err(|_| errors::EsbuildConfigError::ConfigParseError)?;
+
+    parse_esbuild_config(config_content, config_file_type)
+        .map_err(|_| errors::EsbuildConfigError::ConfigParseError)
+}
+
+pub fn read_json_content(path: path::PathBuf) -> Result<String, errors::EsbuildConfigError> {
     match fs::read_to_string(&path) {
         Ok(content) => Ok(content),
         Err(_) => Err(errors::EsbuildConfigError::Io(io::Error::new(
@@ -31,10 +39,16 @@ pub fn esbuild_config_content(path: path::PathBuf) -> Result<String, errors::Esb
 }
 
 // Parse the entire esbuild.config.json
-pub fn parse_esbuild_config(content: String) -> Result<String, errors::ConfigParseError> {
+pub fn parse_esbuild_config(
+    content: String,
+    config_file_type: ConfigFileType,
+) -> Result<String, errors::ConfigParseError> {
     match json::parse(&content) {
-        Ok(value) => args::args_from_json_value(value)
-            .map_err(|_| errors::ConfigParseError::InvalidConfigError),
+        Ok(value) => match config_file_type {
+            ConfigFileType::ConfigJson => args::args_from_config_json_value(value),
+            ConfigFileType::PackageJson => args::args_from_package_json_value(value),
+        }
+        .map_err(|_| errors::ConfigParseError::InvalidConfigError),
         Err(_) => return Err(errors::ConfigParseError::InvalidConfigError),
     }
 }
@@ -45,7 +59,7 @@ mod tests {
 
     #[test]
     fn test_parse_esbuild_config() {
-        let value = r#"
+        let config_json = r#"
             {
                 "entry": "index.js",
                 "a": true,
@@ -55,13 +69,42 @@ mod tests {
             }
         "#;
         assert_eq!(
-            parse_esbuild_config(value.to_string()).unwrap(),
+            parse_esbuild_config(config_json.to_string(), ConfigFileType::ConfigJson).unwrap(),
             "--a --b=abc --c:def --c:ghi --d:e=jkl --d:f=mno index.js"
         );
+        assert!(
+            match parse_esbuild_config("true".to_string(), ConfigFileType::ConfigJson) {
+                Ok(_) => false,
+                Err(_) => true,
+            }
+        );
 
-        assert!(match parse_esbuild_config("true".to_string()) {
-            Ok(_) => false,
-            Err(_) => true,
-        });
+        let package_json = r#"
+            {
+                "esbuild": {
+                    "entry": "index.js",
+                    "a": true,
+                    "b": "abc",
+                    "c": ["def", "ghi"],
+                    "d": { "e": "jkl", "f": "mno" }
+                }
+            }
+        "#;
+        assert_eq!(
+            parse_esbuild_config(package_json.to_string(), ConfigFileType::PackageJson).unwrap(),
+            "--a --b=abc --c:def --c:ghi --d:e=jkl --d:f=mno index.js"
+        );
+        assert!(
+            match parse_esbuild_config("1".to_string(), ConfigFileType::PackageJson) {
+                Ok(_) => false,
+                Err(_) => true,
+            }
+        );
+        assert!(
+            match parse_esbuild_config("{}".to_string(), ConfigFileType::PackageJson) {
+                Ok(_) => false,
+                Err(_) => true,
+            }
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ fn main() {
         Ok(value) => println!("{}", value),
         Err(err) => match err {
             EsbuildConfigError::ConfigParseError => {
-                eprintln!("The configuration file is invalid.");
+                eprintln!("The configuration file or package.json is invalid.");
             }
             EsbuildConfigError::ConfigPathError => {
                 eprintln!("Couldn’t find or open the esbuild configuration file.");


### PR DESCRIPTION
Fixes https://github.com/bpierre/esbuild-config/issues/1

This makes it possible to define the configuration inside the package.json file, using the esbuild field.